### PR TITLE
Update binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,12 +3,12 @@
 		'default_configuration': 'Release',
 		'configurations': {
 			'Common': {
-				'cflags_cc': [ '-std=c++14', '-g', '-Wno-unknown-pragmas' ],
+				'cflags_cc': [ '-std=c++17', '-g', '-Wno-unknown-pragmas' ],
 				'cflags_cc!': [ '-fno-exceptions' ],
 				'xcode_settings': {
 					'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
 					'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES',
-					'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
+					'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
 					'MACOSX_DEPLOYMENT_TARGET': '10.9',
 				},
 				'msvs_settings': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivm-inspect",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist",
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
Compilation failures are being seen when building xxscreeps, these appear to be due to `c++17` not being used when compiling. Such as errors like `std::is_lvalue_reference_v is not a member of std`

note I have not yet validated this fixes the issue